### PR TITLE
메인 페이지 프로젝트 목록 추가 및 프로필 정리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ package-lock.json
 .vscode/
 
 **/*.DS_Store
+
+# Claude Code instructions (contains personal content)
+CLAUDE.md

--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,7 @@ author:
   avatar           : "profile.png"
   name             : "Gwanho Kim"
   pronouns         : "He/Him"
-  bio              : "graduated!!"
+  bio              :
   location         : "Seongnam, South Korea"
   employer         : "Naver Financial"
   uri              : # URL

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -7,6 +7,11 @@ redirect_from:
   - /about.html
 ---
 
-[CS 좀 풀어볼래?](https://cs-quiz-phi.vercel.app/)
+## Projects
+
+- [CS Quiz](https://cs-quiz-phi.vercel.app/) - CS 지식 퀴즈 웹앱 ([repo](https://github.com/khkim6040/cs-quiz))
+- [포스텍 의료공제회 자동완성 플러그인](https://chromewebstore.google.com/detail/postech-%EC%9D%98%EB%A3%8C%EA%B3%B5%EC%A0%9C-%EC%8B%A0%EC%B2%AD-%EC%9E%90%EB%8F%99%EC%99%84%EC%84%B1/gkpfphjlchpdoaofcadidgjnfkdpabka) - 의료공제 신청 자동완성 크롬 익스텐션 ([repo](https://github.com/khkim6040/autofill-postech-medical-form-plugin))
+- [핀테크 기술 뉴스 큐레이션](https://skillful-cake-656.notion.site/30f70179f731801d8091c629c1741b66?v=30f70179f73180058d23000c0c886c29&p=30f70179f731819d92c9e8d990f30813&pm=s) - 핀테크 백엔드 개발자를 위한 일일 기술 뉴스 ([repo](https://github.com/khkim6040/news-curator))
+- [AI 대화 아카이브](https://skillful-cake-656.notion.site/26eb3580606d404abdb98adae50af79d?v=966b9b34165a4a9ab841fafc47f2aa5a) - 쓸모 있을 것 같은 AI와의 대화 모음
 
 ---


### PR DESCRIPTION
## 요약
- GitHub 프로필의 개인 프로젝트들을 메인 페이지에 반영하고, 불필요한 프로필 문구 정리

## 변경 내용
- `_pages/about.md`: CS Quiz, 의료공제회 자동완성 플러그인, 핀테크 뉴스 큐레이션, AI 대화 아카이브 추가
- `_config.yml`: 프로필 bio "graduated!!" 문구 제거
- `.gitignore`: CLAUDE.md 추가

## 테스트
- [ ] localhost:4000에서 메인 페이지 프로젝트 목록 표시 확인 (수동)
- [ ] 프로필 영역에서 bio 문구 제거 확인 (수동)