### PR TITLE
feat: 한/영 언어 토글 기능 추가

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -190,6 +190,7 @@ exclude:
   - README
   - tmp
   - vendor
+  - docs
 keep_files:
   - .git
   - .svn
@@ -237,6 +238,7 @@ defaults:
       comments: true
       share: false
       related: true
+      lang: en
   # _pages
   - scope:
       path: ""

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -9,5 +9,7 @@
 
 main:
   - title: "Hobbies"
+    title_en: "Hobbies"
+    title_ko: "취미"
     url: /hobbies/
 

--- a/_data/ui-text.yml
+++ b/_data/ui-text.yml
@@ -350,5 +350,47 @@ zh-HK: &DEFAULT_ZH_HK
 zh-TW:
   <<: *DEFAULT_ZH_HK
 
+# Korean
+# -----------------
+ko: &DEFAULT_KO
+  page                       : "페이지"
+  pagination_previous        : "이전"
+  pagination_next            : "다음"
+  breadcrumb_home_label      : "홈"
+  breadcrumb_separator       : "/"
+  toc_label                  : "목차"
+  ext_link_label             : "바로가기"
+  less_than                  : "약"
+  minute_read                : "분 소요"
+  share_on_label             : "공유하기"
+  meta_label                 :
+  tags_label                 : "태그:"
+  categories_label           : "카테고리:"
+  date_label                 : "발행일:"
+  comments_label             : "댓글 남기기"
+  comments_title             : "댓글"
+  more_label                 : "더 보기"
+  related_label              : "관련 글"
+  follow_label               : "팔로우:"
+  feed_label                 : "피드"
+  powered_by                 : "Powered by"
+  website_label              : "웹사이트"
+  email_label                : "이메일"
+  recent_posts               : "최근 글"
+  undefined_wpm              : "_config.yml에 words_per_minute가 정의되지 않았습니다"
+  comment_form_info          : "이메일 주소는 공개되지 않습니다. 필수 항목이 표시되어 있습니다"
+  comment_form_comment_label : "댓글"
+  comment_form_md_info       : "마크다운을 지원합니다."
+  comment_form_name_label    : "이름"
+  comment_form_email_label   : "이메일 주소"
+  comment_form_website_label : "웹사이트 (선택)"
+  comment_btn_submit         : "댓글 등록"
+  comment_btn_submitted      : "등록 완료"
+  comment_success_msg        : "댓글 감사합니다! 승인 후 표시됩니다."
+  comment_error_msg          : "죄송합니다, 오류가 발생했습니다. 필수 항목을 확인하고 다시 시도해주세요."
+  loading_label              : "로딩 중..."
+ko-KR:
+  <<: *DEFAULT_KO
+
 # Another locale
 # --------------

--- a/_includes/archive-single.html
+++ b/_includes/archive-single.html
@@ -12,7 +12,7 @@
   {% assign title = post.title %}
 {% endif %}
 
-<div class="{{ include.type | default: "list" }}__item">
+<div class="{{ include.type | default: "list" }}__item archive__item-container" data-post-lang="{{ post.lang | default: 'en' }}" data-post-ref="{{ post.ref }}">
   <article class="archive__item" itemscope itemtype="http://schema.org/CreativeWork">
     {% if include.type == "grid" and teaser %}
       <div class="archive__item-teaser">

--- a/_includes/lang-switch.html
+++ b/_includes/lang-switch.html
@@ -1,0 +1,24 @@
+{% if page.ref %}
+  {% assign translations = "" | split: "" %}
+  {% for p in site.posts %}
+    {% if p.ref == page.ref and p.url != page.url %}
+      {% assign translations = translations | push: p %}
+    {% endif %}
+  {% endfor %}
+  {% for p in site.pages %}
+    {% if p.ref == page.ref and p.url != page.url %}
+      {% assign translations = translations | push: p %}
+    {% endif %}
+  {% endfor %}
+  {% if translations.size > 0 %}
+    <div class="translation-banner">
+      {% for t in translations %}
+        {% if t.lang == "ko" %}
+          <a href="{{ t.url }}">한국어로 읽기</a>
+        {% elsif t.lang == "en" %}
+          <a href="{{ t.url }}">Read in English</a>
+        {% endif %}
+      {% endfor %}
+    </div>
+  {% endif %}
+{% endif %}

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -18,14 +18,14 @@
           <li id="theme-toggle" class="masthead__menu-item persist tail">
             <a role="button" aria-labelledby="theme-icon"><i id="theme-icon" class="fa-solid fa-sun" aria-hidden="true" title="toggle theme"></i></a>
           </li>
-          <li id="lang-toggle" class="masthead__menu-item persist tail">
-            <a role="button" class="lang-toggle-btn" onclick="toggleLanguage()" title="toggle language">
-              <span class="lang-en">EN</span> / <span class="lang-ko">KO</span>
-            </a>
-          </li>
         </ul>
         <ul class="hidden-links hidden"></ul>
       </nav>
+    </div>
+    <div id="lang-toggle">
+      <a role="button" class="lang-toggle-btn" onclick="toggleLanguage()" title="toggle language">
+        <span class="lang-en">EN</span> / <span class="lang-ko">KO</span>
+      </a>
     </div>
   </div>
 </div>

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -13,10 +13,15 @@
             {% else %}
               {% assign domain = base_path %}
             {% endif %}
-            <li class="masthead__menu-item"><a href="{{ domain }}{{ link.url }}">{{ link.title }}</a></li>
+            <li class="masthead__menu-item"><a href="{{ domain }}{{ link.url }}" data-lang-en="{{ link.title_en | default: link.title }}" data-lang-ko="{{ link.title_ko | default: link.title }}">{{ link.title }}</a></li>
           {% endfor %}
           <li id="theme-toggle" class="masthead__menu-item persist tail">
             <a role="button" aria-labelledby="theme-icon"><i id="theme-icon" class="fa-solid fa-sun" aria-hidden="true" title="toggle theme"></i></a>
+          </li>
+          <li id="lang-toggle" class="masthead__menu-item persist tail">
+            <a role="button" class="lang-toggle-btn" onclick="toggleLanguage()" title="toggle language">
+              <span class="lang-en">EN</span> / <span class="lang-ko">KO</span>
+            </a>
           </li>
         </ul>
         <ul class="hidden-links hidden"></ul>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,9 +17,17 @@ layout: compress
       .lang-toggle-btn .lang-ko.active { opacity: 1; }
       .lang-only-label { font-size: 0.75em; opacity: 0.6; margin-left: 0.4em; }
       .translation-banner { padding: 0.5em 1em; background: var(--global-code-bg-color, #f0f0f0); border-radius: 4px; margin-bottom: 1em; font-size: 0.9em; }
-      [data-content-lang] { display: none; }
-      [data-content-lang="en"] { display: block; }
+      html[data-lang="en"] [data-content-lang="ko"] { display: none; }
+      html[data-lang="ko"] [data-content-lang="en"] { display: none; }
     </style>
+    <script>
+      (function() {
+        var lang = localStorage.getItem('site-lang');
+        if (lang === 'ko' || lang === 'en') {
+          document.documentElement.setAttribute('data-lang', lang);
+        }
+      })();
+    </script>
   </head>
 
   <body>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,9 +10,10 @@ layout: compress
     {% include head.html %}
     {% include head/custom.html %}
     <style>
-      #lang-toggle { position: absolute; right: 0; top: 50%; transform: translateY(-50%); }
-      .masthead__inner-wrap { position: relative; }
-      .lang-toggle-btn { cursor: pointer; font-size: 0.85em; font-weight: 600; letter-spacing: 0.02em; padding: 0.25em 0.5em; }
+      .masthead__inner-wrap { display: flex; align-items: center; justify-content: space-between; }
+      .masthead__menu { flex: 1; min-width: 0; }
+      #lang-toggle { flex-shrink: 0; margin-left: 1em; }
+      .lang-toggle-btn { cursor: pointer; font-size: 0.85em; font-weight: 600; letter-spacing: 0.02em; padding: 0.25em 0.5em; white-space: nowrap; }
       .lang-toggle-btn .lang-en,
       .lang-toggle-btn .lang-ko { opacity: 0.4; transition: opacity 0.2s; }
       .lang-toggle-btn .lang-en.active,

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,10 +5,21 @@ layout: compress
 {% include base_path %}
 
 <!doctype html>
-<html lang="{{ site.locale | slice: 0,2 }}" class="no-js"{% if site.site_theme == "dark" %} data-theme="dark"{% endif %}>
+<html lang="{{ site.locale | slice: 0,2 }}" class="no-js"{% if site.site_theme == "dark" %} data-theme="dark"{% endif %} data-lang="en">
   <head>
     {% include head.html %}
     {% include head/custom.html %}
+    <style>
+      .lang-toggle-btn { cursor: pointer; font-size: 0.85em; font-weight: 600; letter-spacing: 0.02em; }
+      .lang-toggle-btn .lang-en,
+      .lang-toggle-btn .lang-ko { opacity: 0.4; transition: opacity 0.2s; }
+      .lang-toggle-btn .lang-en.active,
+      .lang-toggle-btn .lang-ko.active { opacity: 1; }
+      .lang-only-label { font-size: 0.75em; opacity: 0.6; margin-left: 0.4em; }
+      .translation-banner { padding: 0.5em 1em; background: var(--global-code-bg-color, #f0f0f0); border-radius: 4px; margin-bottom: 1em; font-size: 0.9em; }
+      [data-content-lang] { display: none; }
+      [data-content-lang="en"] { display: block; }
+    </style>
   </head>
 
   <body>
@@ -26,6 +37,7 @@ layout: compress
     </div>
 
     {% include scripts.html %}
+    <script src="{{ base_path }}/assets/js/language.js"></script>
 
   </body>
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,9 @@ layout: compress
     {% include head.html %}
     {% include head/custom.html %}
     <style>
-      .lang-toggle-btn { cursor: pointer; font-size: 0.85em; font-weight: 600; letter-spacing: 0.02em; }
+      #lang-toggle { position: absolute; right: 0; top: 50%; transform: translateY(-50%); }
+      .masthead__inner-wrap { position: relative; }
+      .lang-toggle-btn { cursor: pointer; font-size: 0.85em; font-weight: 600; letter-spacing: 0.02em; padding: 0.25em 0.5em; }
       .lang-toggle-btn .lang-en,
       .lang-toggle-btn .lang-ko { opacity: 0.4; transition: opacity 0.2s; }
       .lang-toggle-btn .lang-en.active,

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -44,6 +44,8 @@ layout: default
         </header>
       {% endunless %}
 
+      {% include lang-switch.html %}
+
       <section class="page__content" itemprop="text">
         {{ content }}
 

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -2,11 +2,31 @@
 permalink: /
 title: "Gwanho's Page"
 author_profile: true
-redirect_from: 
+redirect_from:
   - /about/
   - /about.html
 ---
 
-[CS 좀 풀어볼래?](https://cs-quiz-phi.vercel.app/)
+<div data-content-lang="en" markdown="1">
+
+## Projects
+
+- [CS Quiz](https://cs-quiz-phi.vercel.app/) — CS knowledge quiz web app ([repo](https://github.com/khkim6040/cs-quiz))
+- [POSTECH Medical Autocomplete Plugin](https://chromewebstore.google.com/detail/postech-%EC%9D%98%EB%A3%8C%EA%B3%B5%EC%A0%9C-%EC%8B%A0%EC%B2%AD-%EC%9E%90%EB%8F%99%EC%99%84%EC%84%B1/gkpfphjlchpdoaofcadidgjnfkdpabka) — Chrome extension for medical benefit form autocomplete ([repo](https://github.com/khkim6040/autofill-postech-medical-form-plugin))
+- [Fintech News Curation](https://skillful-cake-656.notion.site/30f70179f731801d8091c629c1741b66?v=30f70179f73180058d23000c0c886c29&p=30f70179f731819d92c9e8d990f30813&pm=s) — Daily tech news for fintech backend developers ([repo](https://github.com/khkim6040/news-curator))
+- [AI Conversation Archive](https://skillful-cake-656.notion.site/26eb3580606d404abdb98adae50af79d?v=966b9b34165a4a9ab841fafc47f2aa5a) — Curated useful AI conversations
+
+</div>
+
+<div data-content-lang="ko" markdown="1">
+
+## 프로젝트
+
+- [CS Quiz](https://cs-quiz-phi.vercel.app/) - CS 지식 퀴즈 웹앱 ([repo](https://github.com/khkim6040/cs-quiz))
+- [포스텍 의료공제회 자동완성 플러그인](https://chromewebstore.google.com/detail/postech-%EC%9D%98%EB%A3%8C%EA%B3%B5%EC%A0%9C-%EC%8B%A0%EC%B2%AD-%EC%9E%90%EB%8F%99%EC%99%84%EC%84%B1/gkpfphjlchpdoaofcadidgjnfkdpabka) - 의료공제 신청 자동완성 크롬 익스텐션 ([repo](https://github.com/khkim6040/autofill-postech-medical-form-plugin))
+- [핀테크 기술 뉴스 큐레이션](https://skillful-cake-656.notion.site/30f70179f731801d8091c629c1741b66?v=30f70179f73180058d23000c0c886c29&p=30f70179f731819d92c9e8d990f30813&pm=s) - 핀테크 백엔드 개발자를 위한 일일 기술 뉴스 ([repo](https://github.com/khkim6040/news-curator))
+- [AI 대화 아카이브](https://skillful-cake-656.notion.site/26eb3580606d404abdb98adae50af79d?v=966b9b34165a4a9ab841fafc47f2aa5a) - 쓸모 있을 것 같은 AI와의 대화 모음
+
+</div>
 
 ---

--- a/_posts/2025-08-02-first-post.md
+++ b/_posts/2025-08-02-first-post.md
@@ -2,6 +2,8 @@
 title: 'first post'
 date: 2025-08-02
 permalink: /posts/2025/08/02/
+lang: ko
+ref: first-post
 categories:
   - blog
 tags:

--- a/assets/js/language.js
+++ b/assets/js/language.js
@@ -1,0 +1,94 @@
+(function () {
+  var STORAGE_KEY = 'site-lang';
+  var DEFAULT_LANG = 'en';
+  var SUPPORTED = ['en', 'ko'];
+
+  function getLang() {
+    var stored = localStorage.getItem(STORAGE_KEY);
+    return SUPPORTED.indexOf(stored) !== -1 ? stored : DEFAULT_LANG;
+  }
+
+  function setLang(lang) {
+    if (SUPPORTED.indexOf(lang) === -1) return;
+    localStorage.setItem(STORAGE_KEY, lang);
+    document.documentElement.setAttribute('data-lang', lang);
+    applyLang(lang);
+  }
+
+  function applyLang(lang) {
+    // Toggle UI text elements
+    var textEls = document.querySelectorAll('[data-lang-en]');
+    for (var i = 0; i < textEls.length; i++) {
+      var el = textEls[i];
+      var text = el.getAttribute('data-lang-' + lang);
+      if (text) el.textContent = text;
+    }
+
+    // Toggle lang-specific content blocks
+    var contentEls = document.querySelectorAll('[data-content-lang]');
+    for (var i = 0; i < contentEls.length; i++) {
+      var el = contentEls[i];
+      el.style.display = el.getAttribute('data-content-lang') === lang ? '' : 'none';
+    }
+
+    // Filter archive items by language
+    var archiveEls = document.querySelectorAll('.archive__item-container[data-post-lang]');
+    for (var i = 0; i < archiveEls.length; i++) {
+      var el = archiveEls[i];
+      var postLang = el.getAttribute('data-post-lang');
+      var ref = el.getAttribute('data-post-ref');
+
+      // Remove any existing label
+      var existingLabel = el.querySelector('.lang-only-label');
+      if (existingLabel) existingLabel.remove();
+
+      if (postLang === lang) {
+        el.style.display = '';
+      } else {
+        // Check if a paired translation exists
+        var pair = ref ? document.querySelector(
+          '.archive__item-container[data-post-ref="' + ref + '"][data-post-lang="' + lang + '"]'
+        ) : null;
+        if (pair) {
+          el.style.display = 'none';
+        } else {
+          el.style.display = '';
+          var label = document.createElement('span');
+          label.className = 'lang-only-label';
+          label.textContent = postLang === 'ko' ? ' (Korean only)' : ' (English only)';
+          var titleEl = el.querySelector('.archive__item-title');
+          if (titleEl) titleEl.appendChild(label);
+        }
+      }
+    }
+
+    // Update toggle button
+    var btns = document.querySelectorAll('.lang-toggle-btn');
+    for (var i = 0; i < btns.length; i++) {
+      var enSpan = btns[i].querySelector('.lang-en');
+      var koSpan = btns[i].querySelector('.lang-ko');
+      if (enSpan) {
+        if (lang === 'en') { enSpan.classList.add('active'); } else { enSpan.classList.remove('active'); }
+      }
+      if (koSpan) {
+        if (lang === 'ko') { koSpan.classList.add('active'); } else { koSpan.classList.remove('active'); }
+      }
+    }
+  }
+
+  // Initialize
+  var lang = getLang();
+  document.documentElement.setAttribute('data-lang', lang);
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', function () { applyLang(lang); });
+  } else {
+    applyLang(lang);
+  }
+
+  window.toggleLanguage = function () {
+    var current = getLang();
+    var next = current === 'en' ? 'ko' : 'en';
+    setLang(next);
+  };
+})();


### PR DESCRIPTION
## 요약
- 사이트 전체에 한/영 언어 전환 기능 추가. 네비게이션 바에 KO/EN 토글 버튼으로 UI 라벨, 페이지 컨텐츠, 포스트 목록을 언어별로 전환할 수 있음.

## 변경 내용
- `_data/ui-text.yml`: 한국어 UI 번역 추가
- `assets/js/language.js`: localStorage 기반 언어 상태 관리 및 DOM 토글 JS 모듈
- `_includes/masthead.html`, `_data/navigation.yml`: KO/EN 토글 버튼 및 한/영 네비게이션 타이틀
- `_layouts/default.html`: language.js 로드 및 토글 CSS
- `_includes/archive-single.html`: 포스트 목록 언어 필터링용 data 속성
- `_includes/lang-switch.html`, `_layouts/single.html`: 포스트 페이지 번역 링크 컴포넌트
- `_pages/about.md`: 메인 페이지 한/영 이중 컨텐츠
- `_config.yml`: 포스트 기본 lang 설정, docs/ 빌드 제외

## 테스트
- [x] Docker Jekyll 빌드 성공 확인
- [x] 생성된 HTML에 토글 버튼, data-content-lang, data-post-lang 속성 존재 확인
- [ ] 로컬에서 수동 테스트: KO/EN 토글 시 컨텐츠 전환 동작 확인