### PR TITLE
feat: 일본어(JA) 3개국어 지원 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ package-lock.json
 
 # Claude Code instructions (contains personal content)
 CLAUDE.md
+
+# Handoff documents
+**/HANDOFF.md

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -11,5 +11,6 @@ main:
   - title: "Hobbies"
     title_en: "Hobbies"
     title_ko: "취미"
+    title_ja: "趣味"
     url: /hobbies/
 

--- a/_hobbies/bikes.md
+++ b/_hobbies/bikes.md
@@ -1,10 +1,14 @@
 ---
 title: "Bicycle Riding Adventures"
+title_ja: "自転車ライディング"
 collection: hobbies
 type: "Hobby"
 permalink: /hobbies/bikes/
 excerpt: "My cycling adventures across Korea and California, including cross-country rides and urban exploration."
+excerpt_ja: "韓国とカリフォルニアでのサイクリング冒険。国土縦断や都市探索など。"
 ---
+
+<div data-content-lang="en" markdown="1">
 
 ## Riding a Bicycle
 
@@ -29,3 +33,33 @@ Riding a bicycle around San Francisco, San Jose, and Silicon Valley during my UC
 Crossing the east coast with a bicycle from Pohang to the Unification Observatory(통일전망대) in Goseong, Gangwon-do, 400 km
 
 ![East Coast Cross Country]({{ site.baseurl }}/images/eastcoast_cross_country.png)
+
+</div>
+
+<div data-content-lang="ja" markdown="1">
+
+## 自転車ライディング
+
+### 2024年夏
+仁川から釜山まで自転車で韓国縦断、633km（左が私）
+
+![韓国縦断]({{ site.baseurl }}/images/cross_country.png)
+
+### 2024年秋
+UCB交換留学中に、サンフランシスコ、サンノゼ、シリコンバレー周辺を自転車で走り回った。
+
+![UCB Bike 0]({{ site.baseurl }}/images/UCB_bike0.png)
+![UCB Bike 1]({{ site.baseurl }}/images/UCB_bike1.png)
+![UCB Bike 2]({{ site.baseurl }}/images/UCB_bike2.png)
+
+<video style="width: 100%; max-width: 300px; margin: 10px;" controls loading="lazy" poster="{{ site.baseurl }}/images/UCB_bike_poster.png">
+    <source src="{{ site.baseurl }}/videos/UCB_bike.mp4" type="video/mp4">
+    <p>お使いのブラウザはHTML5動画に対応していません。<a href="{{ site.baseurl }}/videos/UCB_bike.mp4">動画リンク</a>をご利用ください。</p>
+</video>
+
+### 2025年春
+浦項から江原道高城の統一展望台まで東海岸自転車縦断、400km
+
+![東海岸縦断]({{ site.baseurl }}/images/eastcoast_cross_country.png)
+
+</div>

--- a/_hobbies/books.md
+++ b/_hobbies/books.md
@@ -1,10 +1,14 @@
 ---
 title: "Books and Attitude"
+title_ja: "読書と姿勢"
 collection: hobbies
 type: "Hobby"
 permalink: /hobbies/books/
 excerpt: "My reading preferences and life philosophy centered around minimalism and personal growth."
+excerpt_ja: "ミニマリズムと自己成長を軸にした読書の好みと人生哲学。"
 ---
+
+<div data-content-lang="en" markdown="1">
 
 ## Attitude
 - Just Do It
@@ -22,4 +26,28 @@ excerpt: "My reading preferences and life philosophy centered around minimalism 
 ### Novel
 - **Novels by Keigo Higashino**
     - The Murder in the Mansion Masquerade(가면산장 살인사건) was the first book I read by him, and it really shocked me.
-    - I also recommend to read The Miracles of the Namiya General Store(나미야 잡화점의 기적) and Letter(편지) 
+    - I also recommend to read The Miracles of the Namiya General Store(나미야 잡화점의 기적) and Letter(편지)
+
+</div>
+
+<div data-content-lang="ja" markdown="1">
+
+## 姿勢
+- Just Do It
+- ミニマリズム
+
+![一番好きな本]({{ site.baseurl }}/images/fav_book.png)
+
+*一番好きな本：考え方と生き方に影響を与えた本*
+
+## 本
+
+### エッセイ
+- **L'Art de la Simplicite（シンプルに生きる）**
+
+### 小説
+- **東野圭吾の小説**
+    - 「仮面山荘殺人事件」が彼の作品で最初に読んだ本で、本当に衝撃を受けた。
+    - 「ナミヤ雑貨店の奇蹟」と「手紙」もおすすめ。
+
+</div>

--- a/_hobbies/languages.md
+++ b/_hobbies/languages.md
@@ -1,35 +1,73 @@
 ---
 title: "Learning New Languages"
+title_ja: "語学学習"
 collection: hobbies
 type: "Hobby"
 permalink: /hobbies/languages/
 excerpt: "Interest in learning new languages (not programming languages)."
+excerpt_ja: "新しい言語を学ぶことへの関心（プログラミング言語ではなく）。"
 ---
 
-I'm interested in learning new languages. The goal of learning languages is to interact with people without any language barriers.  
+<div data-content-lang="en" markdown="1">
 
-Someday, I hope I can be speakable (not fluent) in the four languages below.  
+I'm interested in learning new languages. The goal of learning languages is to interact with people without any language barriers.
+
+Someday, I hope I can be speakable (not fluent) in the four languages below.
 
 ### English
 
-Of course, it is the most important language everyone should learn. As a native Korean, I've been trying to expose myself to an English-speaking environment—for example, setting the default language on my devices to English and intentionally corrupting my social media algorithms with English content.  
+Of course, it is the most important language everyone should learn. As a native Korean, I've been trying to expose myself to an English-speaking environment—for example, setting the default language on my devices to English and intentionally corrupting my social media algorithms with English content.
 
-I used Speak for about a year. I'm not using it now because it was expensive ($20 per month), and I didn’t like its UX. I've been using epop (말해보카) for about four years. Are they helpful? Well… better than nothing.  
+I used Speak for about a year. I'm not using it now because it was expensive ($20 per month), and I didn't like its UX. I've been using epop (말해보카) for about four years. Are they helpful? Well… better than nothing.
 
-After spending a memorable exchange student period in the US, I re-realized that interacting with native speakers is the best way to learn a new language. It's more painful than just using language learning app, but worth it.  
+After spending a memorable exchange student period in the US, I re-realized that interacting with native speakers is the best way to learn a new language. It's more painful than just using language learning app, but worth it.
 
 ### Japanese
 
-I decided to learn Japanese after having several hard times, especially communicating with a clerk at a drugstore. Papago didn’t work well, and I tried my best to explain what I was looking for. He also tried his best to understand and help me, but in the end, we completely failed to communicate. I felt really bad.  
+I decided to learn Japanese after having several hard times, especially communicating with a clerk at a drugstore. Papago didn't work well, and I tried my best to explain what I was looking for. He also tried his best to understand and help me, but in the end, we completely failed to communicate. I felt really bad.
 
-So, I've been using Duolingo to learn Japanese for over a year. But, you know, Duolingo is more of a snack app than a real learning tool. Thus, in the summer of 2025, I decided to study Japanese more seriously. I bought some books and started teaching myself. I also registered for the **JLPT N3** test this winter. I hope I can pass it.  
+So, I've been using Duolingo to learn Japanese for over a year. But, you know, Duolingo is more of a snack app than a real learning tool. Thus, in the summer of 2025, I decided to study Japanese more seriously. I bought some books and started teaching myself. I also registered for the **JLPT N3** test this winter. I hope I can pass it.
 
 (26.01.31) I PASSED!!
 
 ### Spanish
 
-During my exchange student period, my roommate was from Paraguay, so he spoke Spanish. There were also many Spanish-speaking students in my dorm. I didn’t even know there were so many countries where Spanish is the native language! It was interesting to pick up some Spanish words from them. As a Korean, it would be amazing to travel through Spanish-speaking countries and actually talk with people in their own language.  
+During my exchange student period, my roommate was from Paraguay, so he spoke Spanish. There were also many Spanish-speaking students in my dorm. I didn't even know there were so many countries where Spanish is the native language! It was interesting to pick up some Spanish words from them. As a Korean, it would be amazing to travel through Spanish-speaking countries and actually talk with people in their own language.
 
 ### Chinese
 
-Also, during the exchange student period, I got to know some Chinese friends. It was interesting to hear how they spoke. I tried to learn Chinese with Duolingo, but even though Duolingo is easy to use, I had no idea how to memorize all the Chinese characters I saw. I hope that once I learn more Japanese Kanji—which are similar to Chinese characters—it will help me get the hang of it.  
+Also, during the exchange student period, I got to know some Chinese friends. It was interesting to hear how they spoke. I tried to learn Chinese with Duolingo, but even though Duolingo is easy to use, I had no idea how to memorize all the Chinese characters I saw. I hope that once I learn more Japanese Kanji—which are similar to Chinese characters—it will help me get the hang of it.
+
+</div>
+
+<div data-content-lang="ja" markdown="1">
+
+新しい言語を学ぶことに興味がある。言語を学ぶ目的は、言葉の壁なく人と交流すること。
+
+いつか、以下の4つの言語を（流暢でなくても）話せるようになりたい。
+
+### 英語
+
+もちろん、誰もが学ぶべき最も重要な言語だ。韓国語ネイティブとして、できるだけ英語環境に身を置くようにしてきた。例えば、デバイスのデフォルト言語を英語に設定したり、SNSのアルゴリズムを意図的に英語コンテンツ寄りにしたり。
+
+Speakを約1年使っていたが、月20ドルと高い上にUXも好みじゃなくてやめた。말해보카（epop）は約4年使っている。役に立つかって？まあ…やらないよりはマシ。
+
+アメリカでの交換留学を終えて、ネイティブとの直接会話が一番の学習法だと改めて実感した。アプリより辛いけど、その価値はある。
+
+### 日本語
+
+日本旅行中、薬局の店員さんとコミュニケーションがうまくいかなかった経験がきっかけで、日本語を学ぶことを決めた。Papagoもうまく機能せず、お互い一生懸命伝えようとしたけど、結局完全に失敗した。本当に申し訳なかった。
+
+それでDuolingoで1年以上日本語を勉強した。でもDuolingoは本格的な学習ツールというより、おやつ感覚のアプリだ。そこで2025年の夏、本格的に勉強することにした。教材を買って独学を始め、冬の**JLPT N3**試験に申し込んだ。
+
+（26.01.31）合格した！！
+
+### スペイン語
+
+交換留学中、ルームメイトがパラグアイ出身でスペイン語を話していた。寮にもスペイン語を話す学生がたくさんいた。スペイン語が母語の国がこんなに多いとは知らなかった！ 彼らからスペイン語の単語を少しずつ覚えるのが楽しかった。韓国人としてスペイン語圏の国を旅して、現地の言葉で会話できたら最高だろうなと思う。
+
+### 中国語
+
+交換留学中に中国人の友達もできた。彼らの話し方が面白かった。Duolingoで中国語も試してみたが、使いやすいものの漢字をどう覚えればいいのか全く分からなかった。日本語の漢字をもっと学べば、中国語の感覚もつかめるようになると期待している。
+
+</div>

--- a/_hobbies/music.md
+++ b/_hobbies/music.md
@@ -1,11 +1,25 @@
 ---
 title: "Music"
+title_ja: "音楽"
 collection: hobbies
 type: "Hobby"
 permalink: /hobbies/music/
 excerpt: "My passion for Korean indie music, particularly ThornApple, and my own music projects."
+excerpt_ja: "韓国インディー音楽、特にソンエプル（ThornApple）への情熱と、自分の音楽プロジェクト。"
 ---
+
+<div data-content-lang="en" markdown="1">
 
 ## Music
 
 Big fan of ThornApple, a korean indie band. Check out my [SoundCloud!](https://soundcloud.com/ho0ou)
+
+</div>
+
+<div data-content-lang="ja" markdown="1">
+
+## 音楽
+
+韓国のインディーバンド、ソンエプル（ThornApple）の大ファン。私の[SoundCloud](https://soundcloud.com/ho0ou)もぜひ聴いてみてください！
+
+</div>

--- a/_hobbies/workouts.md
+++ b/_hobbies/workouts.md
@@ -1,13 +1,25 @@
 ---
 title: "Workouts"
+title_ja: "ワークアウト"
 collection: hobbies
 type: "Hobby"
 permalink: /hobbies/workouts/
 excerpt: "My fitness activities and workout routines."
+excerpt_ja: "フィットネス活動とワークアウトルーティン。"
 ---
+
+<div data-content-lang="en" markdown="1">
 
 ## Workouts
 
 *This section is for future workout-related content.*
 
-<!-- Add your workout activities, fitness goals, or exercise routines here -->
+</div>
+
+<div data-content-lang="ja" markdown="1">
+
+## ワークアウト
+
+*このセクションは今後のワークアウト関連コンテンツのためのスペースです。*
+
+</div>

--- a/_includes/archive-single-hobby.html
+++ b/_includes/archive-single-hobby.html
@@ -9,11 +9,11 @@
 <div class="list__item">
   <article class="archive__item" itemscope itemtype="http://schema.org/CreativeWork">
     <h2 class="archive__item-title" itemprop="headline">
-      <a href="{{ base_path }}{{ post.url }}" rel="permalink">{{ title }}</a>
+      <a href="{{ base_path }}{{ post.url }}" rel="permalink" data-lang-en="{{ post.title }}" data-lang-ko="{{ post.title_ko | default: post.title }}" data-lang-ja="{{ post.title_ja | default: post.title }}">{{ title }}</a>
     </h2>
-    
+
     {% if post.excerpt %}
-      <p class="archive__item-excerpt" itemprop="description">{{ post.excerpt | markdownify }}</p>
+      <p class="archive__item-excerpt" itemprop="description" style="font-size: 1em;" data-lang-en="{{ post.excerpt }}" data-lang-ko="{{ post.excerpt }}" data-lang-ja="{{ post.excerpt_ja | default: post.excerpt }}">{{ post.excerpt }}</p>
     {% endif %}
   </article>
 </div> 

--- a/_includes/lang-switch.html
+++ b/_includes/lang-switch.html
@@ -17,6 +17,8 @@
           <a href="{{ t.url }}">한국어로 읽기</a>
         {% elsif t.lang == "en" %}
           <a href="{{ t.url }}">Read in English</a>
+        {% elsif t.lang == "ja" %}
+          <a href="{{ t.url }}">日本語で読む</a>
         {% endif %}
       {% endfor %}
     </div>

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -23,9 +23,9 @@
       </nav>
     </div>
     <div id="lang-toggle" class="lang-toggle-btn">
-      <span class="lang-en" onclick="setLanguage('en')" role="button" title="English"><span class="fi fis fi-us"></span></span>
-      <span class="lang-ko" onclick="setLanguage('ko')" role="button" title="한국어"><span class="fi fis fi-kr"></span></span>
-      <span class="lang-ja" onclick="setLanguage('ja')" role="button" title="日本語"><span class="fi fis fi-jp"></span></span>
+      <button type="button" class="lang-en" data-lang="en" onclick="setLanguage('en')" aria-label="English"><span class="fi fis fi-us"></span></button>
+      <button type="button" class="lang-ko" data-lang="ko" onclick="setLanguage('ko')" aria-label="한국어"><span class="fi fis fi-kr"></span></button>
+      <button type="button" class="lang-ja" data-lang="ja" onclick="setLanguage('ja')" aria-label="日本語"><span class="fi fis fi-jp"></span></button>
     </div>
   </div>
 </div>

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -13,7 +13,7 @@
             {% else %}
               {% assign domain = base_path %}
             {% endif %}
-            <li class="masthead__menu-item"><a href="{{ domain }}{{ link.url }}" data-lang-en="{{ link.title_en | default: link.title }}" data-lang-ko="{{ link.title_ko | default: link.title }}">{{ link.title }}</a></li>
+            <li class="masthead__menu-item"><a href="{{ domain }}{{ link.url }}" data-lang-en="{{ link.title_en | default: link.title }}" data-lang-ko="{{ link.title_ko | default: link.title }}" data-lang-ja="{{ link.title_ja | default: link.title }}">{{ link.title }}</a></li>
           {% endfor %}
           <li id="theme-toggle" class="masthead__menu-item persist tail">
             <a role="button" aria-labelledby="theme-icon"><i id="theme-icon" class="fa-solid fa-sun" aria-hidden="true" title="toggle theme"></i></a>
@@ -22,10 +22,10 @@
         <ul class="hidden-links hidden"></ul>
       </nav>
     </div>
-    <div id="lang-toggle">
-      <a role="button" class="lang-toggle-btn" onclick="toggleLanguage()" title="toggle language">
-        <span class="lang-en">EN</span> / <span class="lang-ko">KO</span>
-      </a>
+    <div id="lang-toggle" class="lang-toggle-btn">
+      <span class="lang-en" onclick="setLanguage('en')" role="button" title="English"><span class="fi fis fi-us"></span></span>
+      <span class="lang-ko" onclick="setLanguage('ko')" role="button" title="한국어"><span class="fi fis fi-kr"></span></span>
+      <span class="lang-ja" onclick="setLanguage('ja')" role="button" title="日本語"><span class="fi fis fi-jp"></span></span>
     </div>
   </div>
 </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,24 +9,26 @@ layout: compress
   <head>
     {% include head.html %}
     {% include head/custom.html %}
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flag-icons@7.5.0/css/flag-icons.min.css">
     <style>
       .masthead__inner-wrap { display: flex; align-items: center; justify-content: space-between; }
       .masthead__menu { flex: 1; min-width: 0; }
       #lang-toggle { flex-shrink: 0; margin-left: 1em; }
-      .lang-toggle-btn { cursor: pointer; font-size: 0.85em; font-weight: 600; letter-spacing: 0.02em; padding: 0.25em 0.5em; white-space: nowrap; }
-      .lang-toggle-btn .lang-en,
-      .lang-toggle-btn .lang-ko { opacity: 0.4; transition: opacity 0.2s; }
-      .lang-toggle-btn .lang-en.active,
-      .lang-toggle-btn .lang-ko.active { opacity: 1; }
+      .lang-toggle-btn { white-space: nowrap; display: flex; gap: 0.3em; align-items: center; }
+      .lang-toggle-btn span { cursor: pointer; opacity: 0.35; transition: opacity 0.2s; display: inline-block; }
+      .lang-toggle-btn span.active { opacity: 1; }
+      .lang-toggle-btn .fi.fis { width: 1.4em; height: 1.4em; border-radius: 50%; background-size: cover; vertical-align: middle; }
       .lang-only-label { font-size: 0.75em; opacity: 0.6; margin-left: 0.4em; }
       .translation-banner { padding: 0.5em 1em; background: var(--global-code-bg-color, #f0f0f0); border-radius: 4px; margin-bottom: 1em; font-size: 0.9em; }
-      html[data-lang="en"] [data-content-lang="ko"] { display: none; }
-      html[data-lang="ko"] [data-content-lang="en"] { display: none; }
+      [data-content-lang] { display: none; }
+      html[data-lang="en"] [data-content-lang="en"] { display: block; }
+      html[data-lang="ko"] [data-content-lang="ko"] { display: block; }
+      html[data-lang="ja"] [data-content-lang="ja"] { display: block; }
     </style>
     <script>
       (function() {
         var lang = localStorage.getItem('site-lang');
-        if (lang === 'ko' || lang === 'en') {
+        if (lang === 'ko' || lang === 'en' || lang === 'ja') {
           document.documentElement.setAttribute('data-lang', lang);
         }
       })();

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,8 +15,8 @@ layout: compress
       .masthead__menu { flex: 1; min-width: 0; }
       #lang-toggle { flex-shrink: 0; margin-left: 1em; }
       .lang-toggle-btn { white-space: nowrap; display: flex; gap: 0.3em; align-items: center; }
-      .lang-toggle-btn span { cursor: pointer; opacity: 0.35; transition: opacity 0.2s; display: inline-block; }
-      .lang-toggle-btn span.active { opacity: 1; }
+      .lang-toggle-btn button { cursor: pointer; opacity: 0.35; transition: opacity 0.2s; background: none; border: none; padding: 0.1em; line-height: 1; }
+      .lang-toggle-btn button.active { opacity: 1; }
       .lang-toggle-btn .fi.fis { width: 1.4em; height: 1.4em; border-radius: 50%; background-size: cover; vertical-align: middle; }
       .lang-only-label { font-size: 0.75em; opacity: 0.6; margin-left: 0.4em; }
       .translation-banner { padding: 0.5em 1em; background: var(--global-code-bg-color, #f0f0f0); border-radius: 4px; margin-bottom: 1em; font-size: 0.9em; }

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -29,4 +29,15 @@ redirect_from:
 
 </div>
 
+<div data-content-lang="ja" markdown="1">
+
+## プロジェクト
+
+- [CS Quiz](https://cs-quiz-phi.vercel.app/) — CS知識クイズWebアプリ ([repo](https://github.com/khkim6040/cs-quiz))
+- [POSTECH医療自動入力プラグイン](https://chromewebstore.google.com/detail/postech-%EC%9D%98%EB%A3%8C%EA%B3%B5%EC%A0%9C-%EC%8B%A0%EC%B2%AD-%EC%9E%90%EB%8F%99%EC%99%84%EC%84%B1/gkpfphjlchpdoaofcadidgjnfkdpabka) — 医療給付申請の自動入力Chrome拡張機能 ([repo](https://github.com/khkim6040/autofill-postech-medical-form-plugin))
+- [フィンテック技術ニュースキュレーション](https://skillful-cake-656.notion.site/30f70179f731801d8091c629c1741b66?v=30f70179f73180058d23000c0c886c29&p=30f70179f731819d92c9e8d990f30813&pm=s) — フィンテックバックエンド開発者向けデイリー技術ニュース ([repo](https://github.com/khkim6040/news-curator))
+- [AI会話アーカイブ](https://skillful-cake-656.notion.site/26eb3580606d404abdb98adae50af79d?v=966b9b34165a4a9ab841fafc47f2aa5a) — 役に立ちそうなAIとの会話コレクション
+
+</div>
+
 ---

--- a/_pages/hobbies.html
+++ b/_pages/hobbies.html
@@ -8,5 +8,5 @@ author_profile: true
 {% include base_path %}
 
 {% for post in site.hobbies %}
-  {% include archive-single.html %}
+  {% include archive-single-hobby.html %}
 {% endfor %} 

--- a/assets/js/language.js
+++ b/assets/js/language.js
@@ -18,6 +18,7 @@
     if (SUPPORTED.indexOf(lang) === -1) return;
     localStorage.setItem(STORAGE_KEY, lang);
     document.documentElement.setAttribute('data-lang', lang);
+    document.documentElement.setAttribute('lang', lang);
     applyLang(lang);
   }
 
@@ -74,16 +75,13 @@
     }
 
     // Update toggle button
-    var btns = document.querySelectorAll('.lang-toggle-btn');
-    for (var i = 0; i < btns.length; i++) {
-      var spans = btns[i].querySelectorAll('span[class^="lang-"]');
-      for (var j = 0; j < spans.length; j++) {
-        var spanLang = spans[j].className.replace('lang-', '').replace(' active', '');
-        if (spanLang === lang) {
-          spans[j].classList.add('active');
-        } else {
-          spans[j].classList.remove('active');
-        }
+    var toggleEls = document.querySelectorAll('.lang-toggle-btn [data-lang]');
+    for (var i = 0; i < toggleEls.length; i++) {
+      var el = toggleEls[i];
+      if (el.getAttribute('data-lang') === lang) {
+        el.classList.add('active');
+      } else {
+        el.classList.remove('active');
       }
     }
   }

--- a/assets/js/language.js
+++ b/assets/js/language.js
@@ -1,7 +1,13 @@
 (function () {
   var STORAGE_KEY = 'site-lang';
   var DEFAULT_LANG = 'en';
-  var SUPPORTED = ['en', 'ko'];
+  var SUPPORTED = ['en', 'ko', 'ja'];
+
+  var LANG_LABELS = {
+    en: { ko: 'Korean only', ja: 'Japanese only' },
+    ko: { en: 'English only', ko: '한국어만', ja: '日本語のみ' },
+    ja: { en: '英語のみ', ko: '韓国語のみ', ja: '日本語のみ' }
+  };
 
   function getLang() {
     var stored = localStorage.getItem(STORAGE_KEY);
@@ -24,11 +30,15 @@
       if (text) el.textContent = text;
     }
 
-    // Toggle lang-specific content blocks
+    // Toggle lang-specific content blocks (fallback to 'en' if no block for current lang)
     var contentEls = document.querySelectorAll('[data-content-lang]');
     for (var i = 0; i < contentEls.length; i++) {
       var el = contentEls[i];
-      el.style.display = el.getAttribute('data-content-lang') === lang ? '' : 'none';
+      var contentLang = el.getAttribute('data-content-lang');
+      var parent = el.parentNode;
+      var hasLangBlock = parent.querySelector('[data-content-lang="' + lang + '"]');
+      var showLang = hasLangBlock ? lang : 'en';
+      el.style.display = contentLang === showLang ? 'block' : 'none';
     }
 
     // Filter archive items by language
@@ -55,7 +65,8 @@
           el.style.display = '';
           var label = document.createElement('span');
           label.className = 'lang-only-label';
-          label.textContent = postLang === 'ko' ? ' (Korean only)' : ' (English only)';
+          var labels = LANG_LABELS[lang] || LANG_LABELS.en;
+          label.textContent = ' (' + (labels[postLang] || postLang) + ')';
           var titleEl = el.querySelector('.archive__item-title');
           if (titleEl) titleEl.appendChild(label);
         }
@@ -65,13 +76,14 @@
     // Update toggle button
     var btns = document.querySelectorAll('.lang-toggle-btn');
     for (var i = 0; i < btns.length; i++) {
-      var enSpan = btns[i].querySelector('.lang-en');
-      var koSpan = btns[i].querySelector('.lang-ko');
-      if (enSpan) {
-        if (lang === 'en') { enSpan.classList.add('active'); } else { enSpan.classList.remove('active'); }
-      }
-      if (koSpan) {
-        if (lang === 'ko') { koSpan.classList.add('active'); } else { koSpan.classList.remove('active'); }
+      var spans = btns[i].querySelectorAll('span[class^="lang-"]');
+      for (var j = 0; j < spans.length; j++) {
+        var spanLang = spans[j].className.replace('lang-', '').replace(' active', '');
+        if (spanLang === lang) {
+          spans[j].classList.add('active');
+        } else {
+          spans[j].classList.remove('active');
+        }
       }
     }
   }
@@ -86,9 +98,7 @@
     applyLang(lang);
   }
 
-  window.toggleLanguage = function () {
-    var current = getLang();
-    var next = current === 'en' ? 'ko' : 'en';
-    setLang(next);
+  window.setLanguage = function (lang) {
+    setLang(lang);
   };
 })();


### PR DESCRIPTION
## 요약
- 포트폴리오 사이트에 일본어를 세 번째 언어로 추가하고, 언어 토글 UX를 개선

## 변경 내용
- **언어 토글 인프라**: EN/KO 2개국어 → EN/KO/JA 3개국어 확장
- **토글 UX 변경**: 순환 클릭 방식 → 국기 아이콘(🇺🇸🇰🇷🇯🇵) 직접 선택 방식 (flag-icons CDN)
- **콘텐츠 번역**: 취미 5개 페이지 + about 페이지 일본어 번역 추가
- **한국어 fallback**: 취미 페이지는 한국어 모드에서 영어 콘텐츠를 표시 (별도 한국어 번역 없음)
- **hobbies 인덱스**: 다국어 제목/excerpt 전환 지원

## 테스트
- [ ] 로컬에서 3개국어 토글 순환 확인 (EN→KO→JA)
- [ ] 취미 페이지 진입 시 언어별 콘텐츠 전환 확인
- [ ] 한국어 모드에서 취미 페이지 영어 fallback 확인
- [ ] about 페이지 일본어 블록 확인