### PR TITLE
feat: 모바일 사이드바 주요 소셜 링크 인라인 노출

### DIFF
--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -34,7 +34,7 @@
   </div>
 
   <div class="author__urls-wrapper">
-    <button class="btn btn--inverse">···</button>
+    <button class="btn btn--inverse" aria-label="More links" aria-expanded="false">···</button>
     <ul class="author__urls social-icons">
       <!-- Font Awesome icons / Biographic information  -->
       {% if author.location %}

--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -20,8 +20,21 @@
     {% if author.bio %}<p class="author__bio">{{ author.bio }}</p>{% endif %}
   </div>
 
+  <!-- Quick social icons: visible only on mobile, inline next to profile -->
+  <div class="author__quick-links">
+    {% if author.github %}
+      <a href="https://github.com/{{ author.github }}" aria-label="GitHub"><i class="fab fa-fw fa-github" aria-hidden="true"></i></a>
+    {% endif %}
+    {% if author.blog %}
+      <a href="{{ author.blog }}" aria-label="Blog"><i class="fas fa-fw fa-home" aria-hidden="true"></i></a>
+    {% endif %}
+    {% if author.cv %}
+      <a href="{{ site.baseurl }}{{ author.cv }}" aria-label="CV"><i class="fas fa-fw fa-file-lines" aria-hidden="true"></i></a>
+    {% endif %}
+  </div>
+
   <div class="author__urls-wrapper">
-    <button class="btn btn--inverse">Follow</button>
+    <button class="btn btn--inverse">···</button>
     <ul class="author__urls social-icons">
       <!-- Font Awesome icons / Biographic information  -->
       {% if author.location %}

--- a/_sass/layout/_sidebar.scss
+++ b/_sass/layout/_sidebar.scss
@@ -157,6 +157,34 @@
   }
 }
 
+/*
+   Quick social links (mobile only)
+   ========================================================================== */
+
+.author__quick-links {
+  display: table-cell;
+  vertical-align: middle;
+  white-space: nowrap;
+
+  a {
+    display: inline-block;
+    padding: 4px 6px;
+    color: inherit;
+    font-size: $type-size-4;
+    text-decoration: none;
+    opacity: 0.7;
+    transition: opacity 0.2s;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
+
+  @include breakpoint($large) {
+    display: none;
+  }
+}
+
 .author__urls-wrapper {
   position: relative;
   display: table-cell;
@@ -214,7 +242,7 @@
     content: "";
     position: absolute;
     top: -11px;
-    left: calc(50% - 10px);
+    right: 15px;
     width: 0;
     border-style: solid;
     border-width: 0 10px 10px;
@@ -231,11 +259,11 @@
     content: "";
     position: absolute;
     top: -10px;
-    left: calc(50% - 10px);
+    right: 15px;
     width: 0;
     border-style: solid;
     border-width: 0 10px 10px;
-    border-color: #fff transparent;
+    border-color: var(--global-bg-color) transparent;
     z-index: 1;
 
     @include breakpoint($large) {

--- a/assets/js/_main.js
+++ b/assets/js/_main.js
@@ -124,6 +124,8 @@ $(document).ready(function () {
   $(".author__urls-wrapper button").on("click", function () {
     $(".author__urls").fadeToggle("fast", function () { });
     $(".author__urls-wrapper button").toggleClass("open");
+    var expanded = $(this).attr("aria-expanded") === "true";
+    $(this).attr("aria-expanded", !expanded);
   });
 
   // Restore the follow menu if toggled on a window resize


### PR DESCRIPTION
## 요약
- 모바일에서 사이드바 소셜 링크 접근성 개선. 기존에는 Follow 버튼을 눌러야만 소셜 링크가 보였으나, 주요 링크를 프로필 옆에 바로 노출

## 변경 내용
- `_includes/author-profile.html`: 모바일 전용 퀵 링크 섹션 추가 (GitHub, Blog, CV), Follow 버튼을 `···`로 변경
- `_sass/layout/_sidebar.scss`: 퀵 링크 스타일 추가 (데스크톱 숨김), 드롭다운 화살표 위치를 버튼 쪽으로 이동, 다크테마 대응

## 테스트
- [ ] 모바일에서 GitHub, Blog, CV 아이콘이 프로필 옆에 인라인 표시되는지 확인
- [ ] ··· 버튼 클릭 시 나머지 링크가 드롭다운으로 표시되는지 확인
- [ ] 드롭다운 화살표가 ··· 버튼 쪽을 가리키는지 확인
- [ ] 데스크톱에서 퀵 링크가 숨겨지고 기존 사이드바가 정상 표시되는지 확인
- [ ] 다크테마에서 드롭다운 화살표 색상이 정상인지 확인